### PR TITLE
题目发送接收，代码同步，实时聊天功能，websocket创建位置调整

### DIFF
--- a/frontend/src/components/AddProblem.vue
+++ b/frontend/src/components/AddProblem.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <tinymce ref="editor" :disabled="disabled" :t="title1" :c="content1">
+    <tinymce @problemPressed="problemPressed" ref="editor" :disabled="disabled" :t="title1" :c="content1">
     </tinymce>
   </div>
 </template>
@@ -21,6 +21,11 @@ export default {
   },
   components:{
     tinymce
-  }
+  },
+  methods:{
+    problemPressed(val){
+        this.$emit("problemsend",val);
+    }
+  },
 }
 </script>

--- a/frontend/src/components/BaseComment.vue
+++ b/frontend/src/components/BaseComment.vue
@@ -1,15 +1,12 @@
 <template>
   <div id="main">
     <el-container id="main-content">
-      <el-header id="chat-title">Chat Online</el-header>
+      <el-header id="chat-title">Chat online</el-header>
       <el-divider></el-divider>
       <el-main id="chat-content">
         <div id="content">
           <div v-for="item in chatHistory" :key="item">
-            <div v-if="typeof item === 'string'">
-              <div style="text-align: center; color: grey; margin-bottom: 20px">
-                {{ item }}
-              </div>
+            <div v-if="typeof item.Ischat === 'undefined'">
             </div>
             <div class="my-msg" v-else-if="item.username === currentUser">
               <div class="message-box">
@@ -60,22 +57,21 @@
   </div>
 </template>
   
-  <script>
+<script>
+ import { inject } from 'vue'
 export default {
+  name:"BaseComment",
   data() {
     return {
       input: "",
       chatHistory: [],
-      currentUser: "wowo1",
+      currentUser: inject('CurrentID'),
       socket: "",
+      Onechat:inject('Onechat'), //用来接收父组件传来的消息
+      chatnum:0
     };
   },
-  created() {
-    this.socket = new WebSocket("ws://localhost:3002");
-    this.socket.onopen = this.onopen;
-    this.socket.onclose = this.onclose;
-    this.socket.onmessage = this.onmessage;
-  },
+  
   mounted() {
     if (localStorage.getItem("chatHistory") === null) {
       localStorage.setItem("chatHistory", "");
@@ -92,26 +88,27 @@ export default {
         document.getElementById("content").scrollIntoView(false);
       });
     },
+    currentUser:{
+      handler(val,oldval){
+        console.log(val);
+        console.log(oldval);
+      }
+    },
+    Onechat:{//判断，当Onechat发生变化时，说明服务器传来了值，这时候判断是否为聊天数据，若是，则增加
+      handler(val,oldval){
+        console.log(oldval);
+        var jsObj = JSON.parse(val);
+        if(typeof(jsObj.Ischat)=="undefined"){
+          return;
+        }
+        console.log("服务端返回的数据:" + val);
+        this.chatHistory.push(jsObj);
+        localStorage.setItem("chatHistory", JSON.stringify(this.chatHistory));
+        },
+        deep: true,
+    }
   },
   methods: {
-    onopen() {
-      console.log("连接建立");
-    },
-    onclose() {
-      console.log("连接关闭");
-    },
-    onmessage(event) {
-      console.log("服务端返回的数据:" + event.data);
-      var jsObj = JSON.parse(event.data);
-      this.chatHistory.push(jsObj);
-      localStorage.setItem("chatHistory", JSON.stringify(this.chatHistory));
-    },
-    add() {
-      let tmp = document.getElementById("value");
-      console.log(tmp.value);
-      this.msg.push(tmp.value);
-      tmp.value = "";
-    },
     sendMsg() {
       if (this.input == "") {
         return;
@@ -119,15 +116,15 @@ export default {
       var mynowmsg = {
         username: this.currentUser,
         input: this.input.trim(),
+        Ischat:1,
+        chatnum:this.chatnum,
       };
-      //this.chatHistory.push(mynowmsg);
-      console.log(this.chatHistory);
-      console.log(this.input);
-      console.log(this.chatHistory);
+      this.chatnum++;
+      
       localStorage.setItem("chatHistory", JSON.stringify(this.chatHistory));
-
+      
       var jsonstr = JSON.stringify(mynowmsg);
-      this.socket.send(jsonstr);
+      this.$emit('fct',jsonstr);
       this.input = "";
     },
   },

--- a/frontend/src/components/BaseProblem.vue
+++ b/frontend/src/components/BaseProblem.vue
@@ -6,14 +6,35 @@
   </div>
 </template>
 <script>
+import { inject } from 'vue'
 export default {
   name: "Document",
   data: function () {
     return {
       title: "",
       content: "",
+      currentUser: inject('CurrentID'),
+      Onechat:inject('Onechat'), 
     };
   },
+  watch: {
+    Onechat:{//判断，当Onechat发生变化时，说明服务器传来了值，这时候判断是否为聊天数据，若是，则增加
+      handler(val,oldval){
+        console.log("hahahahahahah");
+        console.log(oldval);
+        var jsObj = JSON.parse(val);
+        if(typeof(jsObj.IsPorblem)=="undefined"){
+          return;
+        }
+        console.log("服务端返回的数据:" + event.data);
+        this.title=jsObj.title;
+        this.content=jsObj.content;  
+      },
+
+        deep: true,
+    }
+  },
+  /*
   created: function () {
     const self = this;
     var url =
@@ -29,5 +50,6 @@ export default {
         self.content = json[0]["content"];
       });
   },
+  */
 };
 </script>

--- a/frontend/src/components/CodeEditor.vue
+++ b/frontend/src/components/CodeEditor.vue
@@ -1,4 +1,5 @@
 <template>
+    <h1>{{codestr}}</h1>
     <div class="monaco-container">
         <div class="Choose">
             语言：
@@ -42,12 +43,16 @@
 </template>
 <script>
 import MonacoEditor from './MonacoEditor.vue';
-
+import { inject } from 'vue'
 export default {
     name: "CodeEditor",
     components: { MonacoEditor },
     data() {
         return {
+            chatnum:0,
+            Onechat:inject('Onechat'), //用来接收父组件传来的消息
+            codestr:"",//假设这是代码
+            currentUser: inject('CurrentID'),//当前使用者ID，用于判断是面试官还是面试者
             sets: {
                 language: {
                     cpp: "cpp",
@@ -68,6 +73,7 @@ export default {
                     "hc-black": "hc-black",
                 },
             },
+            
             opts: {
                 value: "",
                 readOnly: false, // 是否可编辑
@@ -76,6 +82,22 @@ export default {
             },
         };
     },
+    watch: {
+        Onechat:{//判断，当Onechat发生变化时，说明服务器传来了值，这时候判断是否为聊天数据，若是，则增加
+        handler(val,oldval){
+                console.log(oldval);
+                var jsObj = JSON.parse(val);
+                if(typeof(jsObj.IsCode)=="undefined"){
+                    return;
+                }
+                //console.log(jsObj.IsCode);
+                console.log("服务端返回的数据啊:" + jsObj.value);
+                this.codestr=jsObj.value;
+            },
+            deep: true,
+        }
+    },
+
     methods: {
         changeLanguage(val) {
             this.opts.language = val;
@@ -90,7 +112,20 @@ export default {
         },
         // 内容改变自动获取值
         changeValue(val) {
-            console.log(val);
+            console.log("哈哈哈哈"+val);
+            if(typeof(val)!='string'){
+                return;
+            }
+            var mycode = {
+                username: this.currentUser,
+                value: val,
+                language:this.opts.language,
+                theme:this.opts.theme,
+                IsCode:1,
+                chatnum:this.num,
+            };
+            var jsonstr = JSON.stringify(mycode);
+            this.$emit("codeMsg",jsonstr)
         },
     },
 };

--- a/frontend/src/components/TinymceEditor.vue
+++ b/frontend/src/components/TinymceEditor.vue
@@ -27,6 +27,7 @@
   import 'tinymce/plugins/preview'
   import 'tinymce/plugins/fullscreen'
   import 'tinymce/plugins/help'
+  import { inject } from 'vue'
   export default {
       components: {
           Editor
@@ -57,13 +58,15 @@
           toolbar: {
               type: [String, Array],
               default: 'bold italic underline strikethrough | fontsizeselect | formatselect | forecolor backcolor | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent blockquote | undo redo | removeformat | fullscreen preview'
-          }
+          },
       },
       data () {
           return {
-              str:'',
+              str:"",
               content:"nihao",
               flag:false,
+              currentUser: inject('CurrentID'),
+
           init: {
               language_url: `${this.baseUrl}/tinymce/langs/zh_CN.js`,
               language: 'zh_CN',
@@ -82,16 +85,24 @@
               }
           }
           }
-      },
+    },
       methods:{
-          printf(){
-              alert(this.str)
-          },
-          add(){
+        printf(){
+            alert(this.str);
+            var mynowmsg = {
+                title: this.t,
+                content: this.c,
+                IsPorblem:1,
+            };
+            var jsonstr = JSON.stringify(mynowmsg);
+            this.$emit('problemPressed',jsonstr);
+        },
+        add(){
               this.flag=true,
               console.log(this.c),
               this.str=this.c
-          }
+              
+        },
       },
       mounted () {
           tinymce.init({})

--- a/frontend/src/pages/VieweePage.vue
+++ b/frontend/src/pages/VieweePage.vue
@@ -1,27 +1,76 @@
 <template>
   <el-row>
-    <el-col :span="6">
-      <BaseProblem></BaseProblem>
-    </el-col>
-    <el-col :span="12">
-      <CodeEditor msg="编程部分"></CodeEditor>
-    </el-col>
-    <el-col :span="6">
-      <BaseComment></BaseComment>
-    </el-col>
-  </el-row>
+  <el-col :span="6">
+    <BaseProblem></BaseProblem>
+  </el-col>
+  <el-col :span="12">
+    <CodeEditor msg="编程部分" @codeMsg='codeMsg'></CodeEditor>
+  </el-col>
+  <el-col :span="6">
+    <BaseComment :data='Onechat' @fct='fct'></BaseComment>
+  </el-col>
+</el-row>
 </template>
 <script>
+import { ref,provide} from 'vue';
 import CodeEditor from "../components/CodeEditor.vue";
 import BaseProblem from "../components/BaseProblem.vue";
 import BaseComment from "../components/BaseComment.vue";
 export default {
-  name: "VieweePage",
-  components: {
-    CodeEditor,
-    BaseProblem,
-    BaseComment,
+name: "VieweePage",
+data: function () {
+  return{
+    chatdata:""//用于接收子组件传来的数据
+  }
+},
+setup(){
+  let VieweeID=ref('VieweeID')
+  let Onechat=ref("")//用于将服务器端接收的数据发送到子组件中
+  provide("CurrentID",VieweeID);
+  provide("Onechat",Onechat);
+  return {
+    //把数据引出来，VieweeID用于存放面试者ID标识
+    VieweeID,
+    Onechat,
+  }
+},
+components: {
+  CodeEditor,
+  BaseProblem,
+  BaseComment,
+},
+created() {
+  this.socket = new WebSocket("ws://localhost:3002");
+  this.socket.onopen = this.onopen;
+  this.socket.onclose = this.onclose;
+  this.socket.onmessage = this.onmessage;
+},
+watch:{
+  chatdata:{
+    handler(val,oldval){
+      this.socket.send(val);
+      console.log(oldval);
+    }
+  }
+},
+methods:{
+  fct(val){
+    this.chatdata=val;
   },
+  codeMsg(val){
+    this.chatdata=val;
+  },
+  onopen() {
+    console.log("连接建立");
+  },
+  onclose() {
+    console.log("连接关闭");
+  },
+  onmessage(event) {
+    console.log("服务端返回的数据:" + event.data);
+    this.Onechat=event.data;//赋值，传送到子组件中
+  },
+}
 };
 </script>
 <style scoped>

--- a/frontend/src/pages/ViewerPage.vue
+++ b/frontend/src/pages/ViewerPage.vue
@@ -1,27 +1,80 @@
 <template>
   <el-row>
     <el-col :span="6">
-      <AddProblem></AddProblem>
+      <AddProblem @problemsend="problemsend"></AddProblem>
     </el-col>
     <el-col :span="12">
-      <CodeEditor msg="编程部分"></CodeEditor>
+      <CodeEditor msg="编程部分" @codeMsg='codeMsg'></CodeEditor>
     </el-col>
     <el-col :span="6">
-      <BaseComment></BaseComment>
+      <BaseComment :data='Onechat' @fct='fct'></BaseComment>
     </el-col>
   </el-row>
 </template>
 <script>
+import { ref,provide} from 'vue';
 import CodeEditor from "../components/CodeEditor.vue";
 import AddProblem from "../components/AddProblem.vue";
-import BaseComment from "../components/BaseComment.vue"
+import BaseComment from "../components/BaseComment.vue";
+
 export default {
-  name: "App",
+  name: "ViewrPage",
+  data: function () {
+    return{
+      chatdata:""
+    }
+  },
+  setup(){
+    let ViewerID=ref('ViewerID')
+    let Onechat=ref("")//总发送接口
+    provide("CurrentID",ViewerID);
+    provide("Onechat",Onechat);
+    return{
+      //把数据引出来，VieweeID用于存放面试者ID标识
+      ViewerID,
+      Onechat
+    }
+  },
   components: {
     AddProblem,
     CodeEditor,
     BaseComment,
   },
+  created() {
+    this.socket = new WebSocket("ws://localhost:3002");
+    this.socket.onopen = this.onopen;
+    this.socket.onclose = this.onclose;
+    this.socket.onmessage = this.onmessage;
+  },
+  watch:{
+    chatdata:{
+      handler(val,oldval){
+        this.socket.send(val);
+        console.log(oldval);
+      }
+    }
+  },
+  methods:{
+    fct(val){
+      this.chatdata=val;
+    },
+    codeMsg(val){
+      this.chatdata=val;
+    },
+    problemsend(val){
+      this.chatdata=val;
+    },
+    onopen() {
+      console.log("连接建立");
+    },
+    onclose() {
+      console.log("连接关闭");
+    },
+    onmessage(event) {
+      console.log("服务端返回的数据:" + event.data);
+      this.Onechat=event.data;//赋值，传送到子组件中
+    },
+  }
 };
 </script>
 <style scoped>


### PR DESCRIPTION
将websocket创建的位置调整，分别在ViewerPage和VieweePage，题目发送接收，代码同步以及实时聊天共用一个websocket变量（这个创建放在了ViewerPage和VieweePage当中），通过传值的方式从这三个子部件里传到主页面也就是面试者和面试官页面，然后由面试者页面/面试官页面发送到服务器。
面试者页面/面试官页面接收服务器发送来的信息,然后通过传参的方式传给各自的题目子模块，编辑器子模块，和聊天子模块
QWQ我会不会想的太复杂了
那个编译器里的代码不知道怎么修改，暂时还没找到接口，所以就用文本替代展示下效果
然后给面试官和面试者页面加了个标识，这样本地运行看实时聊天就不用开两个端来看了QAQ